### PR TITLE
isWithinParcel set to true before kicking

### DIFF
--- a/src/parcel.ts
+++ b/src/parcel.ts
@@ -254,8 +254,8 @@ export default class Parcel extends AbstractParcel {
       let tmpPlayer =
         player instanceof Player ? player : new Player(player, this);
 
-      player.isWithinParcel = true;
-      
+      tmpPlayer.isWithinParcel = true;
+
       tmpPlayer.kick(
         `Parcel ${this.id} is private and you're not allowed by the owner.`
       );
@@ -265,6 +265,8 @@ export default class Parcel extends AbstractParcel {
     if (this.allowLoggedInOnly) {
       let tmpPlayer =
         player instanceof Player ? player : new Player(player, this);
+        
+      tmpPlayer.isWithinParcel = true;
 
       if (!tmpPlayer.isLoggedIn()) {
         console.log("[Scripting] non-logged in users not allowed in parcel");

--- a/src/parcel.ts
+++ b/src/parcel.ts
@@ -253,6 +253,9 @@ export default class Parcel extends AbstractParcel {
       // if user is not allowed in parcel kick him.
       let tmpPlayer =
         player instanceof Player ? player : new Player(player, this);
+
+      player.isWithinParcel = true;
+      
       tmpPlayer.kick(
         `Parcel ${this.id} is private and you're not allowed by the owner.`
       );


### PR DESCRIPTION
https://app.shortcut.com/cryptovoxels/story/4630/onplayerenter-if-isallowed-set-iswithinparcel-before-kicking

for `onPlayerEnter` we sets `player.isWithinParcel = true` only after checking to kick em (`allowLoggedInOnly`, `isAllowed`). That tosses up errors. 